### PR TITLE
Fixes latest threejs 0.84.0

### DIFF
--- a/src/createTHREEViewClass.js
+++ b/src/createTHREEViewClass.js
@@ -47,6 +47,16 @@ export default (THREE) => class THREEView extends React.Component {
 
 
   _onContextCreate = (gl) => {
+    let originalGetParameter = gl.getParameter;
+
+    gl.getParameter = function(name) {
+      if (name === gl.VERSION) {
+        return 'WebGL 2.0';
+      } else {
+        return originalGetParameter(name);
+      }
+    }
+
     const renderer = new THREE.WebGLRenderer({
       canvas: {
         width: gl.drawingBufferWidth,


### PR DESCRIPTION
At the moment three.js v0.84.0 is crashing while trying to parse your OpenGL version:
```JavaScript
var version = parseFloat( /^WebGL\ ([0-9])/.exec( gl.getParameter( gl.VERSION ) )[ 1 ] );
```

I’ve looked at the [spec](https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.2) and the required format is:
`<snip> returns a version or release number of the form WebGL<space>2.0<optional><space><vendor-specific information></optional>. <snip>`

On my phone, as expected, I get this: `OpenGL ES 3.2 V@145.0 (GIT@I8b257659a0)`

This fix stubs the gl.getParamter( gl.VERSION ) call to always return "WebGL 2.0".