### PR TITLE
Linear Gradient API update

### DIFF
--- a/src/LinearGradient.android.js
+++ b/src/LinearGradient.android.js
@@ -63,10 +63,10 @@ export default class LinearGradient extends Component {
     // support for current react-native-linear-gradient api
     let startProp = start;
     let endProp = end;
-    if (start && start.x && start.y) {
+    if (start && start.x !== undefined && start.y !== undefined) {
       startProp = [start.x, start.y];
     }
-    if (end && end.x && end.y) {
+    if (end && end.x !== undefined && end.y !== undefined) {
       endProp = [end.x, end.y];
     }
 

--- a/src/LinearGradient.android.js
+++ b/src/LinearGradient.android.js
@@ -12,8 +12,14 @@ import {
 
 export default class LinearGradient extends Component {
   static propTypes = {
-    start: PropTypes.arrayOf(PropTypes.number),
-    end: PropTypes.arrayOf(PropTypes.number),
+    start: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.number),
+        PropTypes.object,
+    ]),
+    end: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.number),
+        PropTypes.object,
+    ]),
     colors: PropTypes.arrayOf(PropTypes.string).isRequired,
     locations: PropTypes.arrayOf(PropTypes.number),
     ...ViewPropTypes,
@@ -54,13 +60,23 @@ export default class LinearGradient extends Component {
       flatStyle.borderBottomLeftRadius || borderRadius,
     ];
 
+    // support for current react-native-linear-gradient api
+    let startProp = start;
+    let endProp = end;
+    if (start && start.x && start.y) {
+      startProp = [start.x, start.y];
+    }
+    if (end && end.x && end.y) {
+      endProp = [end.x, end.y];
+    }
+
     return (
       <View {...otherProps} style={style}>
         <NativeLinearGradient
           style={{ position: 'absolute', top: 0, left: 0, bottom: 0, right: 0 }}
           colors={colors.map(processColor)}
-          start={start}
-          end={end}
+          start={startProp}
+          end={endProp}
           locations={locations ? locations.slice(0, colors.length) : null}
           borderRadii={borderRadiiPerCorner}
         />

--- a/src/LinearGradient.ios.js
+++ b/src/LinearGradient.ios.js
@@ -11,19 +11,35 @@ import {
 
 export default class LinearGradient extends Component {
   static propTypes = {
-    start: PropTypes.arrayOf(PropTypes.number),
-    end: PropTypes.arrayOf(PropTypes.number),
+    start: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.number),
+        PropTypes.object,
+    ]),
+    end: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.number),
+        PropTypes.object,
+    ]),
     colors: PropTypes.arrayOf(PropTypes.string).isRequired,
     locations: PropTypes.arrayOf(PropTypes.number),
     ...ViewPropTypes,
   };
 
   render() {
-    const { colors, locations, ...otherProps } = this.props;
+    const { colors, locations, start, end, ...otherProps } = this.props;
     if (colors && locations && colors.length !== locations.length) {
       console.warn(
         'LinearGradient colors and locations props should be arrays of the same length'
       );
+    }
+
+    // support for current react-native-linear-gradient api
+    let startProp = start;
+    let endProp = end;
+    if (start && start.x && start.y) {
+        startProp = [start.x, start.y];
+    }
+    if (end && end.x && end.y) {
+        endProp = [end.x, end.y];
     }
 
     return (
@@ -31,6 +47,8 @@ export default class LinearGradient extends Component {
         {...otherProps}
         colors={colors.map(processColor)}
         locations={locations ? locations.slice(0, colors.length) : null}
+        start={startProp}
+        end={endProp}
       />
     );
   }

--- a/src/LinearGradient.ios.js
+++ b/src/LinearGradient.ios.js
@@ -35,10 +35,10 @@ export default class LinearGradient extends Component {
     // support for current react-native-linear-gradient api
     let startProp = start;
     let endProp = end;
-    if (start && start.x && start.y) {
+    if (start && start.x !== undefined && start.y !== undefined) {
         startProp = [start.x, start.y];
     }
-    if (end && end.x && end.y) {
+    if (end && end.x !== undefined && end.y !== undefined) {
         endProp = [end.x, end.y];
     }
 


### PR DESCRIPTION
As requested in https://github.com/expo/expo/issues/136 - `react-native-linear-gradient`'s API for `start` and `end` props is now `{ x: number, y: number}` instead of `[number, number]`. Both are now possible to keep backward compatibility.