### PR TITLE
Updates react-native-fbads lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lottie-react-native": "1.1.1",
     "md5-file": "^3.1.1",
     "react-native-branch": "2.0.0-beta.3",
-    "react-native-fbads": "https://github.com/callstack-io/react-native-fbads/tarball/v4.1.0",
+    "react-native-fbads": "https://github.com/callstack-io/react-native-fbads/tarball/v4.2.0",
     "react-native-maps": "https://github.com/expo/react-native-maps/archive/v0.15.2.tar.gz",
     "react-native-svg": "5.2.0",
     "stringify-object": "^3.2.0",


### PR DESCRIPTION
The 4.2.0 version includes the [Fix of flow type annotation](https://github.com/callstack-io/react-native-fbads/pull/50)