### PR TITLE
Text To Speech API

### DIFF
--- a/src/Expo.js
+++ b/src/Expo.js
@@ -159,6 +159,9 @@ module.exports = {
   get ScreenOrientation() {
     return require('./ScreenOrientation');
   },
+  get Speech() {
+    return require('./Speech');
+  },
 };
 
 // add deprecated `Components` module

--- a/src/Speech.js
+++ b/src/Speech.js
@@ -1,0 +1,102 @@
+// @flow
+
+import { NativeModules, NativeEventEmitter } from 'react-native';
+
+const { ExponentSpeech } = NativeModules;
+const SpeechEventEmitter = new NativeEventEmitter(ExponentSpeech);
+
+type Options = {
+  language?: string,
+  pitch?: number,
+  rate?: number,
+  onStart?: () => void,
+  onStopped?: () => void,
+  onDone?: () => void,
+  onError?: (string) => void,
+};
+
+let _GLOBAL_ID = 1;
+
+const _CALLBACKS= {};
+let _LISTENERS_SET = false;
+
+function _unregisterListenersIfNeeded() {
+  if (Object.keys(_CALLBACKS).length === 0) {
+    removeSpeakingListener('Exponent.speakingStarted');
+    removeSpeakingListener('Exponent.speakingDone');
+    removeSpeakingListener('Exponent.speakingStopped');
+    removeSpeakingListener('Exponent.speakingError');
+    _LISTENERS_SET = false;
+  }
+}
+
+function _registerListenersIfNeeded() {
+  if (_LISTENERS_SET) return;
+  _LISTENERS_SET = true;
+  setSpeakingListener('Exponent.speakingStarted', ({ id }) => {
+    const options = _CALLBACKS[id];
+    if (options && options.onStart) {
+      options.onStart();
+    }
+  });
+  setSpeakingListener('Exponent.speakingDone', ({ id }) => {
+    const options = _CALLBACKS[id];
+    if (options && options.onDone) {
+      options.onDone();
+    }
+    delete _CALLBACKS[id];
+    _unregisterListenersIfNeeded();
+  });
+  setSpeakingListener('Exponent.speakingStopped', ({ id }) => {
+    const options = _CALLBACKS[id];
+    if (options && options.onStopped) {
+      options.onStopped();
+    }
+    delete _CALLBACKS[id];
+    _unregisterListenersIfNeeded();
+  });
+  setSpeakingListener('Exponent.speakingError', ({ id, error }) => {
+    const options = _CALLBACKS[id];
+    if (options && options.onError) {
+      options.onError(error);
+    }
+    delete _CALLBACKS[id];
+    _unregisterListenersIfNeeded();
+  });
+}
+
+export function speak(text: string, options: Options = {}) {
+  const id = _GLOBAL_ID++;
+  _CALLBACKS[id] = options;
+  _registerListenersIfNeeded();
+  ExponentSpeech.speak(
+      String(id),
+      text,
+      options,
+  );
+}
+
+export async function isSpeaking(): Promise<boolean> {
+  return await ExponentSpeech.isSpeaking();
+}
+
+export function stop() {
+  ExponentSpeech.stop();
+}
+
+function setSpeakingListener(eventName, callback) {
+  if (SpeechEventEmitter.listeners(eventName).length > 0) {
+    SpeechEventEmitter.removeAllListeners(eventName)
+  }
+  SpeechEventEmitter.addListener(
+      eventName,
+      callback
+  );
+}
+
+function removeSpeakingListener(eventName) {
+  SpeechEventEmitter.removeAllListeners(eventName)
+}
+
+
+


### PR DESCRIPTION
This PR is related to https://github.com/expo/expo/pull/311 .
Add Text-To-Speech API to Expo.

The API exposes 3 methods: **speaking** an utterance, **stopping** it and **checking** if any is in progress.
The passes a `text` to read as an argument and a set of optional `options` : language to use (a valid IETF BCP 47, eg. "en-US"; if none is passed, the device's default is used), voice rate, voice pitch, callbacks for listeners of speaking progress (start, done, stop, error).