### PR TITLE
Add intervalMs option for flexible local notification scheduling

### DIFF
--- a/src/Notifications.js
+++ b/src/Notifications.js
@@ -150,6 +150,7 @@ export default {
     options: {
       time?: Date | number,
       repeat?: 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year',
+      intervalMs?: number,
     } = {}
   ): Promise<LocalNotificationId> {
     // set now at the beginning of the method, to prevent potential
@@ -216,6 +217,24 @@ export default {
           `Please pass one of ['minute', 'hour', 'day', 'week', 'month', 'year'] as the value for the "repeat" option`
         );
       }
+    }
+
+    if (options.intervalMs && Platform.OS === 'ios') {
+      throw new Error(
+        `"intervalMs" option is not supported on iOS`
+      );
+    }
+
+    if (options.intervalMs && options.repeat) {
+      throw new Error(
+        `Please pass either the "repeat" option or "intervalMs" option, not both`
+      );
+    }
+
+    if (options.intervalMs <= 0 || (options.intervalMs && !Number.isInteger(options.intervalMs))) {
+      throw new Error(
+        `Please pass an integer greater than zero as the value for the "intervalMs" option`
+      );
     }
 
     return ExponentNotifications.scheduleLocalNotification(

--- a/src/__tests__/Notifications-tests.js
+++ b/src/__tests__/Notifications-tests.js
@@ -183,6 +183,29 @@ describe('Notifications', () => {
     );
   });
 
+  it('properly passes "options.intervalMs" when scheduling notification on android', async () => {
+    mockPlatformAndroid();
+    const spy = jest.fn();
+    NativeModules.ExponentNotifications.scheduleLocalNotification = spy;
+
+    const notifDate = new Date();
+    await Notifications.scheduleLocalNotificationAsync(
+      { title: 'Android notification' },
+      {
+        // we pass time as number, but below it should be passed as date
+        time: notifDate.getTime(),
+        intervalMs: 1000,
+      }
+    );
+
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    expect(spy).toHaveBeenCalledWith(
+      { data: {}, title: 'Android notification' },
+      { intervalMs: 1000, time: notifDate }
+    );
+  });
+
   it('properly detects invalid time value in scheduled notification options', async () => {
     NativeModules.ExponentNotifications.scheduleLocalNotification = jest.fn();
 
@@ -258,6 +281,101 @@ pass number of seconds since Unix Epoch instead of number of milliseconds?`
         new Error(
           `Please pass one of ['minute', 'hour', 'day', 'week', 'month', \
 'year'] as the value for the "repeat" option`
+        )
+      );
+    }
+
+    expect(
+      NativeModules.ExponentNotifications.scheduleLocalNotification
+    ).toHaveBeenCalledTimes(0);
+  });
+
+  it('properly throws if "options.intervalMs" is used on ios', async () => {
+    mockPlatformIOS();
+    const spy = jest.fn();
+    NativeModules.ExponentNotifications.scheduleLocalNotification = spy;
+    try {
+      await Notifications.scheduleLocalNotificationAsync(
+        mockedScheduledNotifIOS,
+        {
+          intervalMs: 60000
+        }
+      );
+    } catch (e) {
+      expect(e).toEqual(
+        new Error(
+          `"intervalMs" option is not supported on iOS`
+        )
+      );
+    }
+
+    expect(
+      NativeModules.ExponentNotifications.scheduleLocalNotification
+    ).toHaveBeenCalledTimes(0);
+  });
+
+
+  it('properly throws if both "options.repeat" and "options.intervalMs" are set in scheduled notification options on android', async () => {
+    mockPlatformAndroid();
+    NativeModules.ExponentNotifications.scheduleLocalNotification = jest.fn();
+    try {
+      await Notifications.scheduleLocalNotificationAsync(
+        mockedScheduledNotifIOS,
+        {
+          intervalMs: 60000,
+          repeat: 'minute'
+        }
+      );
+    } catch (e) {
+      expect(e).toEqual(
+        new Error(
+          `Please pass either the "repeat" option or "intervalMs" option, not both`
+        )
+      );
+    }
+
+    expect(
+      NativeModules.ExponentNotifications.scheduleLocalNotification
+    ).toHaveBeenCalledTimes(0);
+  });
+
+  it('properly throws for negative number for "options.intervalMs" in scheduled notification options on android', async () => {
+    mockPlatformAndroid();
+    NativeModules.ExponentNotifications.scheduleLocalNotification = jest.fn();
+    try {
+      await Notifications.scheduleLocalNotificationAsync(
+        mockedScheduledNotifIOS,
+        {
+          intervalMs: -1000,
+        }
+      );
+    } catch (e) {
+      expect(e).toEqual(
+        new Error(
+          `Please pass an integer greater than zero as the value for the "intervalMs" option`
+        )
+      );
+    }
+
+    expect(
+      NativeModules.ExponentNotifications.scheduleLocalNotification
+    ).toHaveBeenCalledTimes(0);
+  });
+
+  it('properly throws for non integer for "options.intervalMs" in scheduled notification options on android', async () => {
+    mockPlatformAndroid();
+    NativeModules.ExponentNotifications.scheduleLocalNotification = jest.fn();
+    try {
+      await Notifications.scheduleLocalNotificationAsync(
+        mockedScheduledNotifIOS,
+        {
+          intervalMs: 0.1,
+        }
+      );
+    } catch (e) {
+      expect(e).toEqual(
+        new Error(
+          `Please pass an integer greater than zero as the value for the "intervalMs" option`
         )
       );
     }


### PR DESCRIPTION
Android only option for scheduleLocalNotificationAsync function that enables users to set repeat interval of local notifications to any number of milliseconds.

**Use case**: I need to schedule notifications with a interval of user defined days or hours. Current API enables me to schedule local notification every one hour, or every one day. There is no option to schedule every 5 hours for example. More info here https://forums.expo.io/t/flexible-repeat-for-local-notification-scheduling/1441

This change enables users to set repeat interval in milliseconds for maximum flexibility.

**Added code is completely covered by unit tests.**

I will also make a pull request to the expo client project with this small commit that enables this change:
https://github.com/lvojnovic/expo/commit/77b0f26ee0d2d78c7d9c626c2a612f030761446a

Unfortunately, I was not able to setup my local expo client with local expo-sdk. Client would not start in the simulator (Kernel manifest invalid. Make sure `exp start` is running inside of exponent/js/__internal__ and rebuild the app) even though I had `exp start` running in the js folder. There is no __internal__ folder. When I tried __develop__ folder I got `Unexpected token import` after cloning expo-dev/react-native-lab. I also tried running expo-dev following the instructions in the README. It also failed to run tools/setup (Error: Cannot find module '/Users/{MYUSER}/workspace/expo-dev/react-native-lab/react-native/local-cli/core/rn-cli.config.js').