### PR TITLE
react native maps version up

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "qs": "^6.5.0",
     "react-native-branch": "2.0.0-beta.3",
     "react-native-gesture-handler": "1.0.0-alpha.41",
-    "react-native-maps": "0.19.0",
+    "react-native-maps": "0.20.1",
     "react-native-svg": "6.2.1",
     "uuid-js": "^0.7.5",
     "websql": "https://github.com/expo/node-websql/archive/18.0.0.tar.gz"


### PR DESCRIPTION
react-native-maps weren't compatible with expo's version of react-native:

npm WARN react-native-maps@0.19.0 requires a peer of react@16.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN react-native-maps@0.19.0 requires a peer of react-native@0.51.0 but none is installed. You must install peer dependencies yourself.