### PR TITLE
Fix warnings to reflect deprecated usage

### DIFF
--- a/src/Util.js
+++ b/src/Util.js
@@ -17,14 +17,14 @@ export function getCurrentDeviceCountryAsync(): Promise<string> {
 
 export function getCurrentLocaleAsync(): Promise<string> {
   console.warn(
-    'Util.getCurrentDeviceCountryAsync is deprecated, use Localization.getCurrentDeviceCountryAsync'
+    'Util.getCurrentLocaleAsync is deprecated, use Localization.getCurrentLocaleAsync'
   );
   return Localization.getCurrentLocaleAsync();
 }
 
 export function getCurrentTimeZoneAsync(): Promise<string> {
   console.warn(
-    'Util.getCurrentDeviceCountryAsync is deprecated, use Localization.getCurrentDeviceCountryAsync'
+    'Util.getCurrentTimeZoneAsync is deprecated, use Localization.getCurrentTimeZoneAsync'
   );
   return Localization.getCurrentTimeZoneAsync();
 }


### PR DESCRIPTION
Noticed that the warnings seem to contain the wrong method call which might confuse users.