### PR TITLE
AppReview

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react-native-branch": "2.0.0-beta.3",
     "react-native-gesture-handler": "1.0.0-alpha.41",
     "react-native-maps": "0.21.0",
+    "react-native-store-review": "0.1.5",
     "react-native-svg": "6.2.2",
     "uuid-js": "^0.7.5",
     "websql": "https://github.com/expo/node-websql/archive/18.0.0.tar.gz"

--- a/src/appReview/AppReview.js
+++ b/src/appReview/AppReview.js
@@ -1,0 +1,145 @@
+import { Platform, Alert, Linking } from 'react-native';
+import StoreReview from 'react-native-store-review';
+
+import RatingsData from './AppReview';
+
+export const buttonTypes = {
+  NEUTRAL_DELAY: 'NEUTRAL_DELAY',
+  NEGATIVE_DECLINE: 'NEGATIVE_DECLINE',
+  POSITIVE_ACCEPT: 'POSITIVE_ACCEPT',
+};
+
+const _config = {
+  title: 'Rate Me',
+  message:
+    "We hope you're loving our app. If you are, would you mind taking a quick moment to leave us a positive review?",
+  appStoreId: null,
+  actionLabels: {
+    decline: "Don't ask again",
+    delay: 'Maybe later...',
+    accept: 'Sure!',
+  },
+  timingFunction(currentCount) {
+    return currentCount > 1 && (Math.log(currentCount) / Math.log(3)).toFixed(4) % 1 === 0;
+  },
+  buttonOrder: {
+    ios: [buttonTypes.NEGATIVE_DECLINE, buttonTypes.NEUTRAL_DELAY, buttonTypes.POSITIVE_ACCEPT],
+    android: [buttonTypes.NEGATIVE_DECLINE, buttonTypes.NEUTRAL_DELAY, buttonTypes.POSITIVE_ACCEPT],
+  },
+  shouldBoldLastButton: true,
+};
+
+async function _isAwaitingRating() {
+  const timestamps = await RatingsData.getActionTimestamps();
+
+  // If no timestamps have been set yet we are still awaiting the user, return true
+  return timestamps.every(timestamp => {
+    return timestamp[1] === null;
+  });
+}
+
+/**
+ * Creates the RatingRequestor object you interact with
+ * @class
+ */
+export default class RatingRequestor {
+  /**
+   * @param  {string} appStoreId - Required. The ID used in the app's respective app store
+   * @param  {object} options - Optional. Override the defaults. Takes the following shape, with all elements being optional:
+   * 								{
+   * 									title: {string},
+   * 									message: {string},
+   * 									actionLabels: {
+   * 										decline: {string},
+   * 										delay: {string},
+   * 										accept: {string}
+   * 									},
+   * 									buttonOrder: {
+   * 										ios: [buttonTypes],
+   * 										android: [buttonTypes],
+   * 									}
+   * 									shouldBoldLastButton: {boolean},
+   * 									timingFunction: {func}
+   * 								}
+   */
+  constructor(appStoreId, options) {
+    // Check for required options
+    if (!appStoreId) {
+      console.error(
+        "You must specify your app's store ID on construction to use the Rating Requestor."
+      );
+    }
+
+    // Merge defaults with user-supplied config
+    Object.assign(_config, options);
+    _config.appStoreId = appStoreId;
+
+    this.storeUrl = Platform.select({
+      ios: `https://itunes.apple.com/us/app/appName/id${_config.appStoreId}`,
+      android: `market://details?id=${_config.appStoreId}`,
+    });
+  }
+
+  /**
+   * Shows the rating dialog when called. Normally called by `handlePositiveEvent()`, but
+   * can be called on its own as well. Use caution when doing so--you don't want to ask
+   * the user for a rating too frequently or you might annoy them. (This is handy, however,
+   * if the user proactively seeks out something in your app to leave a rating, for example.)
+   *
+   * @param {function(didAppear: boolean, result: string)} callback Optional. Callback that reports whether the dialog appeared and what the result was.
+   */
+  showRatingDialog(callback = () => {}) {
+    const buttonDefaults = {
+      NEGATIVE_DECLINE: {
+        text: _config.actionLabels.decline,
+        onPress: () => {
+          RatingsData.recordDecline();
+          callback(true, 'decline');
+        },
+      },
+      NEUTRAL_DELAY: {
+        text: _config.actionLabels.delay,
+        onPress: () => {
+          callback(true, 'delay');
+        },
+      },
+      POSITIVE_ACCEPT: {
+        text: _config.actionLabels.accept,
+        onPress: () => {
+          RatingsData.recordRated();
+          callback(true, 'accept');
+          Linking.openURL(this.storeUrl);
+        },
+        style: 'default',
+      },
+    };
+
+    const buttons = Platform.select(_config.buttonOrder).map(bo => buttonDefaults[bo]);
+
+    if (_config.shouldBoldLastButton) {
+      buttons[2].style = 'cancel';
+    }
+
+    Alert.alert(_config.title, _config.message, buttons);
+  }
+
+  /**
+   * Call when a positive interaction has occurred within your application. Depending on the number
+   * of times this has occurred and your timing function, this may display a rating request dialog.
+   *
+   * @param {function(didAppear: boolean, result: string)} callback Optional. Callback that reports whether the dialog appeared and what the result was.
+   */
+  async handlePositiveEvent(callback = () => {}) {
+    if (await _isAwaitingRating()) {
+      const currentCount = await RatingsData.incrementCount();
+      if (_config.timingFunction(currentCount)) {
+        if (StoreReview.isAvailable) {
+          StoreReview.requestReview();
+          callback(true, 'SKStoreReviewController');
+        } else {
+          this.showRatingDialog(callback);
+        }
+      } else callback(false);
+    } else callback(false);
+  }
+}

--- a/src/appReview/AppReviewData.js
+++ b/src/appReview/AppReviewData.js
@@ -1,0 +1,81 @@
+import { AsyncStorage } from 'react-native';
+
+const keyPrefix = '@RatingRequestData.';
+const eventCountKey = keyPrefix + 'positiveEventCount';
+const ratedTimestamp = keyPrefix + 'ratedTimestamp';
+const declinedTimestamp = keyPrefix + 'declinedTimestamp';
+
+/**
+ * Private class that let's us interact with AsyncStorage on the device
+ * @class
+ */
+class RatingsData {
+  constructor() {
+    this.initialize();
+  }
+
+  // Get current count of positive events
+  async getCount() {
+    try {
+      const countString = await AsyncStorage.getItem(eventCountKey);
+      return parseInt(countString, 10);
+    } catch (error) {
+      console.warn("Couldn't retrieve positive events count. Error:", error);
+    }
+  }
+
+  // Increment count of positive events
+  async incrementCount() {
+    try {
+      const currentCount = await this.getCount();
+      await AsyncStorage.setItem(eventCountKey, (currentCount + 1).toString());
+
+      return currentCount + 1;
+    } catch (error) {
+      console.warn('Could not increment count. Error:', error);
+    }
+  }
+
+  async getActionTimestamps() {
+    try {
+      const timestamps = await AsyncStorage.multiGet([ratedTimestamp, declinedTimestamp]);
+
+      return timestamps;
+    } catch (error) {
+      console.warn('Could not retrieve rated or declined timestamps.', error);
+    }
+  }
+
+  async recordDecline() {
+    try {
+      await AsyncStorage.setItem(declinedTimestamp, Date.now().toString());
+    } catch (error) {
+      console.warn("Couldn't set declined timestamp.", error);
+    }
+  }
+
+  async recordRated() {
+    try {
+      await AsyncStorage.setItem(ratedTimestamp, Date.now().toString());
+    } catch (error) {
+      console.warn("Couldn't set rated timestamp.", error);
+    }
+  }
+
+  // Initialize keys, if necessary
+  async initialize() {
+    try {
+      const keys = await AsyncStorage.getAllKeys();
+
+      if (!keys.some(key => key === eventCountKey)) {
+        console.log('Initializing blank values...');
+        await AsyncStorage.setItem(eventCountKey, '0');
+      }
+    } catch (error) {
+      // report error or maybe just initialize the values?
+      console.warn('Uh oh, something went wrong initializing values!', error);
+    }
+  }
+}
+
+export default new RatingsData();


### PR DESCRIPTION
Idea is to have a single function to call when a "PositiveEvent" happens. After an appropriate amount of positive events, ask for a review. Depending on device and iOS version either an in-app event is triggered or a Alert with accept, delay, deny. 

The code here is not in anyway complete just a proof of concept.

This is one possible implementation of AppReview. Another less invasive way is to only implement something similar to what oblador/react-native-store-review is and let developers just call isAvailable, requestReview. 

https://github.com/jlyman/react-native-rating-requestor
https://github.com/oblador/react-native-store-review