### PR TITLE
add method startActivityWithUriAsync to launch intent with Uri

### DIFF
--- a/src/IntentLauncherAndroid.js
+++ b/src/IntentLauncherAndroid.js
@@ -102,17 +102,13 @@ export const ACTION_ZEN_MODE_SCHEDULE_RULE_SETTINGS =
   'android.settings.ZEN_MODE_SCHEDULE_RULE_SETTINGS';
 export const ACTION_ZEN_MODE_SETTINGS = 'android.settings.ZEN_MODE_SETTINGS';
 
-export function startActivityAsync(activity: string, data: ?Object = null): Promise<boolean> {
+export function startActivityAsync(
+  activity: string,
+  data: ?Object = null,
+  uri: ?string = null
+): Promise<boolean> {
   if (Platform.OS === 'android') {
-    return NativeModules.ExponentIntentLauncher.startActivity(activity, data);
-  } else {
-    return Promise.reject(new Error('Unsupported platform'));
-  }
-}
-
-export function startActivityWithUriAsync(activity: string, uri: ?string = null): Promise<boolean> {
-  if (Platform.OS === 'android') {
-    return NativeModules.ExponentIntentLauncher.startActivityWithUri(activity, uri);
+    return NativeModules.ExponentIntentLauncher.startActivity(activity, data, uri);
   } else {
     return Promise.reject(new Error('Unsupported platform'));
   }

--- a/src/IntentLauncherAndroid.js
+++ b/src/IntentLauncherAndroid.js
@@ -109,3 +109,11 @@ export function startActivityAsync(activity: string, data: ?Object = null): Prom
     return Promise.reject(new Error('Unsupported platform'));
   }
 }
+
+export function startActivityWithUriAsync(activity: string, uri: ?string = null): Promise<boolean> {
+  if (Platform.OS === 'android') {
+    return NativeModules.ExponentIntentLauncher.startActivityWithUri(activity, uri);
+  } else {
+    return Promise.reject(new Error('Unsupported platform'));
+  }
+}


### PR DESCRIPTION
Implements missing ability to launch intent with Uri by separate IntentLauncher method `startActivityWithUri`. For example, you may use it to open specific app preferences by passing the URI with its package name ('package:host.exp.exponent' for example).

Related to: https://github.com/expo/expo/pull/1713

UPDATE: 
Implements missing ability to launch intent with Uri by adding 3rd parameter 'uri' to the startActivityAsync method