### PR TITLE
Add close DB function to SQLite.

### DIFF
--- a/src/SQLite.js
+++ b/src/SQLite.js
@@ -22,6 +22,7 @@ function massageError(err) {
 
 function SQLiteDatabase(name) {
   this._name = name;
+  this._closed = false;
 }
 
 function dearrayifyRow(res) {
@@ -72,6 +73,10 @@ function escapeBlob(data) {
 }
 
 SQLiteDatabase.prototype.exec = function exec(queries, readOnly, callback) {
+  if (this._closed) {
+    throw new Error('Database was closed.')
+  }
+
   function onSuccess(rawResults) {
     var results = map(rawResults, dearrayifyRow);
     callback(null, results);
@@ -83,6 +88,11 @@ SQLiteDatabase.prototype.exec = function exec(queries, readOnly, callback) {
 
   ExponentSQLite.exec(this._name, map(queries, arrayifyQuery), readOnly).then(onSuccess, onError);
 };
+
+SQLiteDatabase.prototype.close = function close() {
+  this._closed = true;
+  ExponentSQLite.close(this._name);
+}
 
 const openDB = customOpenDatabase(SQLiteDatabase);
 


### PR DESCRIPTION
Extends the SQLite Database API with a new `close()` method.
For details see: https://github.com/expo/expo/issues/639#issuecomment-393901728

For the native code checkout the PR in expo/expo: https://github.com/expo/expo/pull/1821
