### PR TITLE
Add e2e flag to disable iOS render delay

### DIFF
--- a/src/launch/AppLoadingNativeWrapper.ios.js
+++ b/src/launch/AppLoadingNativeWrapper.ios.js
@@ -7,9 +7,14 @@ export default class AppLoading extends React.Component<{}> {
   componentWillUnmount() {
     // Until we give more control over this, give the app 200ms to render
     // something and prevent a white flash
-    setTimeout(() => {
-      NativeModules.ExponentAppLoadingManager.finishedAsync();
-    }, 200);
+    const reportFinished =
+      () => NativeModules.ExponentAppLoadingManager.finishedAsync();
+    // Don't do this when running the app in e2e testing mode
+    if (global.__E2E__) {
+      reportFinished()
+    } else {
+      setTimeout(reportFinished, 200);
+    }
   }
 
   render() {


### PR DESCRIPTION
This PR enables the [detox-expo-helpers](https://github.com/expo/detox-expo-helpers) to work again on recent versions of the Expo SDK.

By adding `global.__E2E__ = true` in the `init.js` function of your Detox suite, you can prevent Expo from wrapping`finishedAsync` in a `setTimeout`, which seems to break Detox's ability to listen for it. A white flash isn't problematic when you're just running automated tests.