### PR TITLE
Revert "Add e2e flag to disable iOS render delay"

### DIFF
--- a/src/launch/AppLoadingNativeWrapper.ios.js
+++ b/src/launch/AppLoadingNativeWrapper.ios.js
@@ -7,14 +7,9 @@ export default class AppLoading extends React.Component<{}> {
   componentWillUnmount() {
     // Until we give more control over this, give the app 200ms to render
     // something and prevent a white flash
-    const reportFinished =
-      () => NativeModules.ExponentAppLoadingManager.finishedAsync();
-    // Don't do this when running the app in e2e testing mode
-    if (global.__E2E__) {
-      reportFinished()
-    } else {
-      setTimeout(reportFinished, 200);
-    }
+    setTimeout(() => {
+      NativeModules.ExponentAppLoadingManager.finishedAsync();
+    }, 200);
   }
 
   render() {


### PR DESCRIPTION
Reverts expo/expo-sdk#113
Fixing this so we can re-commit 8ad2a665df348c106dcdb75836db0e47142b653e back into master w/ expbot